### PR TITLE
metacua: match the Swift tool-result contract in the Python backend

### DIFF
--- a/03_use_cases/13_macos_cua/python/metacua/muse_spark.py
+++ b/03_use_cases/13_macos_cua/python/metacua/muse_spark.py
@@ -158,29 +158,44 @@ class MuseSparkBackend(LLMBackend):
         self, runs: List[ToolRun], screenshot, notes: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         items: List[Dict[str, Any]] = []
-        for index, run in enumerate(runs):
+        for run in runs:
             output_text = ("ERROR: " + run.output) if run.is_error else run.output
-            output: Any = output_text
-            if index == len(runs) - 1:
-                content: List[Dict[str, Any]] = [{"type": "input_text", "text": output_text}]
-                if screenshot is not None:
-                    content.append(
-                        {
-                            "type": "input_text",
-                            "text": "Screen observation after the action:",
-                        }
-                    )
-                    content.append(self._image_block(screenshot))
-                else:
-                    content.append({"type": "input_text", "text": "[screenshot unavailable]"})
-                output = content
             items.append(
                 {
                     "type": "function_call_output",
                     "call_id": run.call_id,
-                    "output": output,
+                    "output": output_text,
                 }
             )
+
+        # The screenshot is returned as a user message rather than inside the
+        # tool output. `function_call_output` carries the textual result of a
+        # custom function tool; image parts are only defined for the built-in
+        # computer-use tool's `computer_call_output`. Servers that map the
+        # Responses API onto chat completions reject image parts here, since a
+        # chat `role: "tool"` message has no place to put them. This mirrors
+        # what the OSWorld backend already does.
+        content: List[Dict[str, Any]] = []
+        if notes:
+            content.append(
+                {
+                    "type": "input_text",
+                    "text": "Some actions were not executed: " + "; ".join(notes),
+                }
+            )
+        if screenshot is None:
+            content.append(
+                {
+                    "type": "input_text",
+                    "text": "[screenshot unavailable; the previous screen may be stale]",
+                }
+            )
+        else:
+            content.append(
+                {"type": "input_text", "text": "Screen observation after the action:"}
+            )
+            content.append(self._image_block(screenshot))
+        items.append({"role": "user", "type": "message", "content": content})
         return items
 
 

--- a/03_use_cases/13_macos_cua/python/tests/test_muse_spark_tool_results.py
+++ b/03_use_cases/13_macos_cua/python/tests/test_muse_spark_tool_results.py
@@ -1,0 +1,96 @@
+"""Tool-result shape for the Muse Spark backend.
+
+The Swift backend (src/metacua/MuseSparkBackend.swift) returns a plain string
+from `function_call_output` and sends the screenshot as a following user
+message. These tests pin the Python backend to the same contract.
+"""
+import types
+
+from metacua.llm import ToolRun
+from metacua.muse_spark import MuseSparkBackend
+
+
+def _backend():
+    config = types.SimpleNamespace(
+        base_url="http://localhost:1/v1", api_key="k", model="m",
+        allow_bash=False, batched_actions=False, effort="low", max_images=5,
+    )
+    return MuseSparkBackend(config)
+
+
+def _screenshot():
+    shot = types.SimpleNamespace()
+    shot.png_base64 = "AAAA"
+    shot.width, shot.height = 100, 80
+    return shot
+
+
+def _runs(n=1):
+    return [
+        ToolRun(call_id=f"call_{i}", name="computer.computer",
+                output="Action executed.", is_error=False)
+        for i in range(n)
+    ]
+
+
+def test_function_call_output_is_a_string():
+    """Images belong to computer_call_output, not function_call_output."""
+    items = _backend().tool_result_items(_runs(), _screenshot())
+    outputs = [i for i in items if i.get("type") == "function_call_output"]
+    assert len(outputs) == 1
+    assert isinstance(outputs[0]["output"], str)
+    assert outputs[0]["call_id"] == "call_0"
+
+
+def test_screenshot_is_sent_as_a_user_message():
+    items = _backend().tool_result_items(_runs(), _screenshot())
+    messages = [i for i in items if i.get("type") == "message"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    kinds = [part["type"] for part in messages[0]["content"]]
+    assert "input_image" in kinds
+    assert kinds.index("input_text") < kinds.index("input_image")
+
+
+def test_no_image_parts_inside_any_tool_output():
+    items = _backend().tool_result_items(_runs(3), _screenshot())
+    for item in items:
+        if item.get("type") == "function_call_output":
+            assert "input_image" not in str(item["output"])
+
+
+def test_every_run_gets_its_own_output_item():
+    items = _backend().tool_result_items(_runs(3), _screenshot())
+    outputs = [i for i in items if i.get("type") == "function_call_output"]
+    assert [o["call_id"] for o in outputs] == ["call_0", "call_1", "call_2"]
+
+
+def test_errors_are_marked():
+    runs = [ToolRun(call_id="c", name="computer.computer",
+                    output="boom", is_error=True)]
+    items = _backend().tool_result_items(runs, _screenshot())
+    output = next(i for i in items if i.get("type") == "function_call_output")
+    assert output["output"].startswith("ERROR: ")
+
+
+def test_missing_screenshot_still_reports_to_the_model():
+    items = _backend().tool_result_items(_runs(), None)
+    message = next(i for i in items if i.get("type") == "message")
+    text = " ".join(p.get("text", "") for p in message["content"])
+    assert "screenshot" in text.lower()
+    assert all(p["type"] != "input_image" for p in message["content"])
+
+
+def test_notes_are_surfaced():
+    items = _backend().tool_result_items(_runs(), _screenshot(), notes=["skipped x"])
+    message = next(i for i in items if i.get("type") == "message")
+    text = " ".join(p.get("text", "") for p in message["content"])
+    assert "skipped x" in text
+
+
+def test_screenshot_survives_when_there_are_no_runs():
+    """agent.py calls this with runs=[] after a step with no tool calls."""
+    items = _backend().tool_result_items([], _screenshot())
+    messages = [i for i in items if i.get("type") == "message"]
+    assert len(messages) == 1
+    assert any(p["type"] == "input_image" for p in messages[0]["content"])


### PR DESCRIPTION
The Swift and Python backends disagree about how a tool result is shaped, and the Python side is the one that departs from the Responses API.

## The difference

Swift returns a plain string and sends the screenshot as a following user message — [`MuseSparkBackend.swift:175-197`](../blob/main/03_use_cases/13_macos_cua/src/metacua/MuseSparkBackend.swift):

```swift
items.append([
  "type": "function_call_output",
  "call_id": run.callId,
  "output": run.isError ? "ERROR: " + run.output : run.output,   // plain string
])
...
items.append(["role": "user", "type": "message", "content": content])  // screenshot here
```

Python packs the screenshot into the tool result instead:

```python
content = [{"type": "input_text", "text": output_text},
           {"type": "input_text", "text": "Screen observation after the action:"},
           self._image_block(screenshot)]        # input_image inside the tool output
output = content
```

So the README's claim that the agent is "built twice ... against the identical Muse Spark contract" doesn't hold today.

## Why Python's shape is the wrong one

Image parts in a tool result belong to the built-in computer-use tool's `computer_call_output`. `function_call_output` carries the **textual** result of a custom function tool — and metacua registers `computer.computer` as a custom function tool (`{"type": "function", ...}`), not `computer_use_preview`.

This matters beyond spec pedantry. Servers that implement the Responses API by translating it to chat completions cannot represent it, because a chat `role: "tool"` message has no image slot. Against llama.cpp, step 1 of every run succeeds and step 2 fails with:

```
400 Output of tool call should be 'Input text'
```

## Compatibility

Verified against `muse-spark-1.2` on `api.meta.ai` — **both shapes return 200** and produce a `computer.computer` call, so this is not a behaviour change for existing users:

| tool-result shape | muse-spark-1.2 |
|---|---|
| image inside `function_call_output` (before) | 200 |
| string + screenshot as user message (after) | 200 |

Also confirmed unchanged:
- `retain_most_recent_images` trims identically across 9 step/limit combinations — the traversal is recursive and shape-agnostic
- `call_id` linkage preserved
- nothing outside `muse_spark.py` references `function_call_output`

## Two Python-only bugs fixed along the way

Neither exists in Swift:

- **`notes` was accepted and silently dropped.** It is now surfaced to the model.
- **`agent.py:172` calls this with `runs=[]`** after a step with no tool calls. Because the loop body never ran, the screenshot was discarded entirely and the model got no observation for that step.

## Tests

`tool_result_items` had no coverage. Adds 8 tests pinning the contract; **7 fail against the previous behaviour**. Full suite: 59 passed.

Swift is unchanged — it already does this.
