### PR TITLE
Add Muse Voice Transcribe recipe (06_muse_voice)

### DIFF
--- a/06_muse_voice/01_voice_api_fundamentals/README.md
+++ b/06_muse_voice/01_voice_api_fundamentals/README.md
@@ -1,0 +1,123 @@
+# Speech to text
+
+|  |  |
+|---|---|
+| **Section** | [Muse Voice Transcribe](../) |
+| **Docs** | [Speech to text](https://dev.meta.ai/docs/speech-to-text) · [API reference](https://dev.meta.ai/docs/api-reference/voice) |
+| **Time to complete** | ~10 min |
+| **Model** | `muse-voice-transcribe-1.0` |
+| **Language** | Python |
+| **Prerequisites** | Python 3.10+, the `websockets` and `requests` packages, a `MODEL_API_KEY`, and a mono 16-bit WAV. [ffmpeg](https://ffmpeg.org/) to convert audio, and [sounddevice](https://pypi.org/project/sounddevice/) for microphone input. |
+
+Muse Voice Transcribe turns speech into text across 25 languages, and the model handles punctuation, speech-boundary detection and speaker attribution itself.
+
+There are two ways to use it, and this recipe demonstrates both:
+
+| Script | Endpoint | Use it when |
+|---|---|---|
+| `transcribe_stream.py` | `wss://api.meta.ai/v1/asr/realtime` | You want transcripts while the speaker is still talking — a microphone, a call, or a file played at real time. |
+| `transcribe_file.py` | `https://api.meta.ai/v1/asr/transcribe` | You already have a recording and just want the text back as fast as it uploads. |
+
+Shared client code for both lives in `utils.py`.
+
+## Setup
+
+```bash
+pip install websockets requests
+export MODEL_API_KEY="<your Model API key>"
+```
+
+Both scripts take the same input: a **mono 16-bit WAV** at 24 kHz (engine-native) or 16 kHz. The sampling is identical either way; only the transport differs. The streaming endpoint receives the raw PCM frames read out of that file, which is what the `PCM_24KHZ` and `PCM_16KHZ` encoding names refer to, while the one-shot endpoint uploads the WAV itself. Convert anything else first:
+
+```bash
+ffmpeg -i input.mp3 -ac 1 -ar 24000 -sample_fmt s16 sample.wav
+```
+
+## Stream a recording
+
+```bash
+python transcribe_stream.py sample.wav
+```
+
+```
+session 89465FD9A818F4B89CBA1501C4A4C1BC
+Where is the capital of Switzerland?
+```
+
+Watch it live and the transcript builds and revises itself: `Where` → `Where is the` → `Where is the capital of` → `Where is the capital of Switzerland?`
+
+Partials are **cumulative** — each one replaces the last, so render in place rather than appending. The `final: true` frame is the completion signal.
+
+## Dictate from a microphone
+
+```bash
+pip install sounddevice
+python transcribe_stream.py --mic
+```
+
+Two things change. It defaults to `ENDPOINTING` so the model finds turn boundaries instead of waiting for you to declare them — pass `--mode` explicitly to override that — and it drops the pacer, because a microphone already produces audio in real time.
+
+## Attribute speech to speakers with diarization
+
+```bash
+python transcribe_stream.py meeting.wav --mode DIARIZATION
+```
+
+```
+[A]
+turn 0: What do we got? Let's see, a couple of different health trackers...
+[B]
+turn 1: But first, did they even test this? I have one for YouTube.
+```
+
+The turn lifecycle is `speechStart` → partials → `speaker` → `speechEnd` → `speechComplete`. A `speaker` event labels the span *before* it, and `speechComplete` arrives asynchronously, so correlate by `turnId` rather than by arrival order. Diarization covers non-overlapping speech.
+
+## Transcribe a recording in one request
+
+```bash
+python transcribe_file.py interview.wav --mode DIARIZATION
+```
+
+```
+[   1.52s] A: How is the weather?
+[   5.90s] B: It is raining.
+```
+
+One HTTP `POST`, one JSON response carrying the whole transcript plus a `turns` array. Two differences from the streaming endpoint catch people out: the credential goes in an `Authorization` **header** rather than inside the handshake, and there is no pacing — you upload as fast as your connection allows.
+
+Speaker labels are bare letters on both endpoints, so a turn carries `"speaker": "A"`, not `speaker_a`.
+
+## Modes
+
+| Mode | Who ends the turn | Use it for |
+|---|---|---|
+| `PUSH_TO_TALK` | You do | Push-to-talk, transcribing a file |
+| `ENDPOINTING` | The model detects speech start and end | Live dictation, voice agents |
+| `DIARIZATION` | The model, plus speaker labels | Meetings, interviews, calls |
+
+Both endpoints share these three names, and `PUSH_TO_TALK` is the default on each. Mode is fixed at the handshake and cannot change mid-session. Not every model serves every mode, and asking for one it does not serve is rejected before any audio is accepted.
+
+## Bias the transcription
+
+Both endpoints accept two optional biasing parameters, and each script exposes one flag per parameter. Both parameters are lists of strings, so repeat a flag to send several values.
+
+```bash
+python transcribe_stream.py standup.wav --keywords Anaya --keywords Kolkata
+python transcribe_file.py interview.wav --language-bias english
+```
+
+`--keywords` populates the endpoint's `keywords` parameter — use it for names, jargon, and product words the model would otherwise mis-hear. `--language-bias` populates `languageBias` — use it when you already know the language. Both nudge the model rather than constrain it, so neither guarantees an exact spelling.
+
+## Cutoff behaviour
+
+| What the server checks | Close code |
+|---|---|
+| No handshake within 10 seconds | `1008` |
+| More than 5 seconds of audio backlog, so don't blast a file at full speed | `1008` |
+| Ingress below real time for 10 seconds, so pad silence during gaps | `1008` |
+| Streaming session open longer than 60 minutes | `1011` |
+| Rate limited | `1013` |
+
+The model has a streaming cap of 60 minutes. The one-shot endpoint is capped at 10 minutes of audio or 32 MB, whichever comes first.
+
+The pacing rules cut both ways, which is why the client paces against an absolute schedule rather than sleeping a fixed amount per chunk. Sleep a flat interval and every slow send adds drift, until ten seconds of accumulated lateness closes the session.

--- a/06_muse_voice/01_voice_api_fundamentals/transcribe_file.py
+++ b/06_muse_voice/01_voice_api_fundamentals/transcribe_file.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Transcribe a recording in one request over the Muse Voice Transcribe file endpoint.
+
+    python transcribe_file.py interview.wav
+    python transcribe_file.py interview.wav --mode DIARIZATION
+
+Streaming is paced at real time, so a five-minute recording takes five
+minutes. This uploads as fast as your connection allows and returns one JSON
+response. To watch transcripts arrive live instead, see transcribe_stream.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from utils import DEFAULT_MODE, MODES, TranscribeError, transcribe_recording
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audio", help="audio file to transcribe")
+    parser.add_argument(
+        "--mode",
+        default=DEFAULT_MODE,
+        choices=MODES,
+        help=f"DIARIZATION also labels who spoke (default: {DEFAULT_MODE})",
+    )
+    parser.add_argument(
+        "--keywords",
+        action="append",
+        metavar="TERM",
+        help="bias recognition toward a term; repeat for several",
+    )
+    parser.add_argument(
+        "--language-bias",
+        action="append",
+        metavar="LANG",
+        help="hint the expected language; repeat for several. Omit to autodetect",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = transcribe_recording(
+            args.audio,
+            mode=args.mode,
+            keywords=args.keywords,
+            language_bias=args.language_bias,
+        )
+    except (TranscribeError, RuntimeError, OSError) as exc:
+        print(f"{exc}", file=sys.stderr)
+        return 1
+
+    # Read every field defensively: `turns` is absent outside the speech modes,
+    # and `speaker` is present only in DIARIZATION.
+    turns = result.get("turns")
+    if turns:
+        # Speech modes return the transcript split into turns, with timings.
+        # Diarization adds a speaker label to each one.
+        for turn in turns:
+            who = f"{turn['speaker']}: " if turn.get("speaker") else ""
+            start = (turn.get("startMs") or 0) / 1000
+            print(f"[{start:7.2f}s] {who}{turn.get('transcript', '')}")
+    else:
+        print(result.get("transcript", ""))
+
+    duration = (result.get("audioDurationMs") or 0) / 1000
+    print(
+        f"\n{duration:.1f}s of audio, session {result.get('sessionId')}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/06_muse_voice/01_voice_api_fundamentals/transcribe_stream.py
+++ b/06_muse_voice/01_voice_api_fundamentals/transcribe_stream.py
@@ -1,0 +1,211 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Transcribe live audio over the Muse Voice Transcribe streaming endpoint.
+
+    python transcribe_stream.py sample.wav
+    python transcribe_stream.py meeting.wav --mode DIARIZATION
+    python transcribe_stream.py --mic                 # Ctrl-C to stop
+
+Audio is paced at real time, so transcripts arrive while the audio is still
+uploading. To send a recording all at once instead, see transcribe_file.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sys
+import wave
+from collections.abc import AsyncIterator
+
+from utils import (
+    CHUNK_MS,
+    DEFAULT_MODE,
+    MODES,
+    SAMPLE_RATES,
+    StreamError,
+    chunk_pcm,
+    read_wav,
+    transcribe_stream,
+)
+
+# Queue depth is added latency: a frame waits here before it is sent, so a deep
+# queue delays every transcript behind it. Two frames is the floor worth having.
+# One would drop audio whenever the loop runs two `_offer` callbacks before the
+# consumer is scheduled, which happens under ordinary jitter; two absorbs that
+# and nothing more. Note `maxsize=0` means unbounded, not empty.
+MIC_QUEUE_FRAMES = 160 // CHUNK_MS
+
+
+async def mic_chunks(encoding: str) -> AsyncIterator[bytes]:
+    """Yield raw PCM from the default input device until cancelled.
+
+    The sounddevice callback runs on its own thread, so it hands chunks over
+    with `call_soon_threadsafe`. The queue is an `asyncio.Queue`, so awaiting
+    the next chunk yields to the event loop instead of blocking it.
+
+    The queue is bounded. If the sender falls behind real time -- a network
+    stall, say -- an unbounded queue would hoard raw PCM for the life of the
+    process, and the server would drop the session for slow ingress anyway.
+    Discarding the oldest frame keeps memory flat and the stream current.
+    """
+    import sounddevice as sd  # optional dependency, only needed for --mic
+
+    rate = SAMPLE_RATES[encoding]
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=MIC_QUEUE_FRAMES)
+
+    def on_audio(indata, _frames, _time, status) -> None:
+        if status:
+            print(status, file=sys.stderr)
+        loop.call_soon_threadsafe(_offer, bytes(indata))
+
+    def _offer(frame: bytes) -> None:
+        if queue.full():
+            queue.get_nowait()
+            print("microphone buffer full; dropped a frame", file=sys.stderr)
+        queue.put_nowait(frame)
+
+    stream = sd.RawInputStream(
+        samplerate=rate,
+        channels=1,
+        dtype="int16",
+        blocksize=int(rate * CHUNK_MS / 1000),
+        callback=on_audio,
+    )
+    # Closing the stream on the way out matters: without it the input device
+    # stays open until the process exits.
+    with stream:
+        while True:
+            yield await queue.get()
+
+
+def _clear_line(width: int) -> None:
+    """Erase the in-progress partial before printing a permanent line."""
+    print(f"\r{' ' * width}\r", end="", flush=True)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("audio", nargs="?", help="mono 16-bit WAV to stream")
+    source.add_argument(
+        "--mic", action="store_true", help="stream from the microphone instead"
+    )
+    parser.add_argument(
+        "--mode",
+        default=None,
+        choices=MODES,
+        help=(
+            f"who decides where an utterance ends "
+            f"(default: {DEFAULT_MODE}, or ENDPOINTING with --mic)"
+        ),
+    )
+    parser.add_argument(
+        "--encoding",
+        default="PCM_24KHZ",
+        choices=list(SAMPLE_RATES),
+        help="must match the audio's sample rate (default: PCM_24KHZ)",
+    )
+    parser.add_argument(
+        "--keywords",
+        action="append",
+        metavar="TERM",
+        help="bias recognition toward a term; repeat for several",
+    )
+    parser.add_argument(
+        "--language-bias",
+        action="append",
+        metavar="LANG",
+        help="hint the expected language; repeat for several. Omit to autodetect",
+    )
+    args = parser.parse_args()
+
+    if args.mic:
+        chunks: object = mic_chunks(args.encoding)
+        # A microphone already produces audio in real time, so adding a pacer
+        # on top would push us behind.
+        pace = False
+        # Let the model find turn boundaries rather than waiting for endStream.
+        # Only when the caller did not ask for a mode: `--mode` defaults to None
+        # so an explicit `--mic --mode PUSH_TO_TALK` is still honoured.
+        mode = "ENDPOINTING" if args.mode is None else args.mode
+        print("Listening. Speak, then press Ctrl-C to finish.", file=sys.stderr)
+    elif args.audio:
+        try:
+            chunks = chunk_pcm(read_wav(args.audio, args.encoding), args.encoding)
+        except (ValueError, OSError, wave.Error) as exc:
+            print(f"Cannot read {args.audio}: {exc}", file=sys.stderr)
+            return 1
+        pace = True
+        mode = args.mode or DEFAULT_MODE
+    else:  # pragma: no cover - argparse rejects this first
+        parser.error("pass an audio file, or --mic")
+
+    speaker = None
+    width = max(40, shutil.get_terminal_size((100, 24)).columns - 1)
+    try:
+        async for event in transcribe_stream(
+            chunks,
+            mode=mode,
+            encoding=args.encoding,
+            pace=pace,
+            keywords=args.keywords,
+            language_bias=args.language_bias,
+        ):
+            kind = event["type"]
+
+            if kind == "session":
+                print(f"session {event['sessionId']}", file=sys.stderr)
+
+            elif kind == "transcript":
+                # Partials are cumulative: each one replaces the last, so
+                # rewrite the line rather than appending to it. Truncate a
+                # partial to the terminal width as well as padding to it -- one
+                # that is longer wraps onto a second row, and the carriage
+                # return then only rewinds that row, so partials would stack
+                # instead of overwriting. The final transcript is the result
+                # rather than a progress line, so it is printed whole.
+                if event["final"]:
+                    _clear_line(width)
+                    print(event["transcript"])
+                else:
+                    print(
+                        f"{event['transcript'][:width]:<{width}}", end="\r", flush=True
+                    )
+
+            elif kind == "speaker":
+                # Labels the span of speech that preceded this event. Labels are
+                # bare letters -- `A`, `B` -- on both endpoints.
+                if event["label"] != speaker:
+                    speaker = event["label"]
+                    _clear_line(width)
+                    print(f"[{speaker}]", flush=True)
+
+            elif kind == "speechComplete":
+                # The whole-turn transcript. It arrives asynchronously, so
+                # correlate turns by matching turnId, not by arrival order and
+                # not by assuming the numbering starts anywhere in particular.
+                _clear_line(width)
+                print(f"turn {event['turnId']}: {event['transcript'].strip()}")
+
+    except (StreamError, RuntimeError, OSError) as exc:
+        # RuntimeError covers a missing MODEL_API_KEY, which is raised before
+        # the socket opens. Matches transcribe_file.py so neither CLI answers a
+        # setup mistake with a traceback.
+        print(f"\n{exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        pass

--- a/06_muse_voice/01_voice_api_fundamentals/utils.py
+++ b/06_muse_voice/01_voice_api_fundamentals/utils.py
@@ -1,0 +1,405 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared client code for the two Muse Voice Transcribe endpoints.
+
+`transcribe_stream()` streams audio over the realtime WebSocket and yields
+events as they arrive. `transcribe_recording()` posts a whole recording to the
+one-shot HTTP endpoint and returns a single response.
+
+Both are used by the two CLIs in this recipe: `transcribe_stream.py` and
+`transcribe_file.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+import wave
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+import requests
+import websockets
+
+# The engine is native at 24 kHz; 16 kHz is accepted and resampled server-side.
+SAMPLE_RATES: dict[str, int] = {"PCM_16KHZ": 16000, "PCM_24KHZ": 24000}
+
+# How much audio to put in each binary frame. Frame boundaries carry no meaning
+# to the server, but smaller frames lower latency. This matches the backend's
+# 80 ms processing chunk; the server does not require it and may change that
+# cadence, so do not depend on the two staying equal.
+CHUNK_MS = 80
+
+# Both endpoints are served from the Model API host.
+DEFAULT_STREAM_URL = "wss://api.meta.ai/v1/asr/realtime"
+DEFAULT_TRANSCRIBE_URL = "https://api.meta.ai/v1/asr/transcribe"
+
+# The public model name.
+DEFAULT_MODEL = "muse-voice-transcribe-1.0"
+
+# Both endpoints share one Mode enum, so the same three names work on each.
+# `PUSH_TO_TALK` is the default: the caller delimits the turn, by ending the
+# stream or by uploading a whole clip. Keep the CLIs' `--mode` choices bound to
+# this tuple -- the server ignores an unrecognised mode rather than rejecting
+# it, so a stale name would silently transcribe in the wrong mode.
+MODES = ("PUSH_TO_TALK", "ENDPOINTING", "DIARIZATION")
+DEFAULT_MODE = MODES[0]
+
+# --- One-shot request details -----------------------------------------------
+
+# The one-shot endpoint reads an Authorization header, unlike the streaming
+# handshake which carries the credential in JSON.
+AUTH_SCHEME = "Bearer"
+
+AUDIO_FORMAT_FIELD = "audioEncoding"
+AUDIO_FORMAT_VALUE = "WAV"
+
+# 10 minutes of audio, or 32 MB, whichever comes first. A realtime session is
+# capped separately and far higher. Oversized bodies return 413; over-long
+# audio returns 400 once the server has decoded it.
+MAX_BYTES = 32 * 1024 * 1024
+
+
+class TranscribeError(RuntimeError):
+    """The server rejected the request or failed to transcribe it."""
+
+
+class StreamError(RuntimeError):
+    """The server sent an error event or closed the session abnormally."""
+
+
+def read_wav(path: str, encoding: str = "PCM_24KHZ") -> bytes:
+    """Read a mono 16-bit WAV whose sample rate matches `encoding`.
+
+    The API takes raw PCM with no container, so this strips the WAV header and
+    hands back the sample data. Converting other formats is a job for ffmpeg,
+    not this client -- see the recipe README.
+    """
+    want = SAMPLE_RATES[encoding]
+    with wave.open(path, "rb") as w:
+        channels, width, rate, frames = (
+            w.getnchannels(),
+            w.getsampwidth(),
+            w.getframerate(),
+            w.getnframes(),
+        )
+        data = w.readframes(frames)
+
+    problems = []
+    if channels != 1:
+        problems.append(f"{channels} channels (need mono)")
+    if width != 2:
+        problems.append(f"{width * 8}-bit samples (need 16-bit)")
+    if rate != want:
+        problems.append(f"{rate} Hz (need {want} Hz for {encoding})")
+    if problems:
+        raise ValueError(
+            f"{path}: {', '.join(problems)}. Convert it with:\n"
+            f"  ffmpeg -i {path} -ac 1 -ar {want} -sample_fmt s16 converted.wav"
+        )
+    return data
+
+
+def chunk_pcm(
+    pcm: bytes, encoding: str = "PCM_24KHZ", chunk_ms: int = CHUNK_MS
+) -> Iterable[bytes]:
+    """Split raw PCM into fixed-duration chunks."""
+    size = int(SAMPLE_RATES[encoding] * 2 * chunk_ms / 1000)
+    for i in range(0, len(pcm), size):
+        yield pcm[i : i + size]
+
+
+def _normalize(frame: dict[str, Any]) -> dict[str, Any]:
+    """Return every server frame as a flat `type`-tagged dict.
+
+    Events arrive internally tagged, e.g. `{"type": "transcript", ...}`. The
+    handshake response is the exception: it is a struct rather than a union, so
+    it comes back as a bare `{"sessionId": "..."}` with no `type`.
+    """
+    if "type" in frame:
+        return frame
+    if "sessionId" in frame:
+        return {"type": "session", "sessionId": frame["sessionId"]}
+    return {"type": "unknown", **frame}
+
+
+def _closed(exc: Exception) -> StreamError | None:
+    """Turn an abnormal close into an error that says what to do about it.
+
+    Returns None for a clean 1000 close, which is how a finished session ends
+    and not something the caller should hear about.
+    """
+    code = getattr(exc, "code", None)
+    if code == 1000:
+        return None
+    reason = (getattr(exc, "reason", "") or "").strip()
+    advice = {
+        1008: "bad request, or audio was paced too slowly or too fast",
+        1011: "server error, or the maximum session duration was reached",
+        1013: "rate limited; back off and reconnect",
+    }.get(code, "connection closed unexpectedly")
+    detail = f": {reason}" if reason else ""
+    return StreamError(f"[{code}] {advice}{detail}")
+
+
+async def _as_async(chunks: Any) -> AsyncIterator[bytes]:
+    """Iterate either a sync iterable or an async one.
+
+    A file reader is a plain generator. A live microphone is better modelled as
+    an async iterator, so that waiting for the next chunk yields to the event
+    loop instead of blocking every other task on it.
+    """
+    if hasattr(chunks, "__aiter__"):
+        async for chunk in chunks:
+            yield chunk
+    else:
+        for chunk in chunks:
+            yield chunk
+
+
+async def _send_audio(
+    ws: Any, chunks: Any, *, pace: bool, encoding: str, end_frame: str
+) -> None:
+    """Stream audio, then half-close the input.
+
+    Runs as a background task so the caller can read events while this uploads.
+    """
+    # Derive elapsed audio from the bytes actually sent rather than assuming
+    # every chunk is full-sized: the last chunk of a file usually is not, and a
+    # caller may hand us variable-sized ones.
+    bytes_per_second = SAMPLE_RATES[encoding] * 2
+    started = time.monotonic()
+    elapsed_audio = 0.0
+    async for chunk in _as_async(chunks):
+        await ws.send(chunk)  # binary frame
+        elapsed_audio += len(chunk) / bytes_per_second
+        if pace:
+            # Pace against an absolute schedule rather than sleeping a fixed
+            # amount per chunk: that way slow sends catch up instead of
+            # drifting further behind and tripping the real-time monitor.
+            behind = started + elapsed_audio - time.monotonic()
+            if behind > 0:
+                await asyncio.sleep(behind)
+
+    # Pausing is not enough: this half-closes the audio input while leaving the
+    # socket open for the events still in flight.
+    await ws.send(end_frame)
+
+
+async def transcribe_stream(
+    chunks: Any,
+    *,
+    token: str | None = None,
+    model: str | None = None,
+    mode: str = DEFAULT_MODE,
+    encoding: str = "PCM_24KHZ",
+    url: str | None = None,
+    pace: bool = True,
+    keywords: list[str] | None = None,
+    language_bias: list[str] | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """Stream `chunks` of raw PCM and yield transcript events as they arrive.
+
+    Args:
+        chunks: Iterable of raw PCM byte strings, in the format named by
+            `encoding`. Either a plain iterable or an async one.
+        token: Session credential. Defaults to `$MODEL_API_KEY`.
+        model: Public model name. Defaults to `DEFAULT_MODEL`.
+        mode: `PUSH_TO_TALK` (you decide when the utterance ends),
+            `ENDPOINTING` (the model detects speech boundaries), or
+            `DIARIZATION` (endpointing plus speaker labels).
+        encoding: `PCM_24KHZ` or `PCM_16KHZ`.
+        url: Streaming endpoint. Defaults to `DEFAULT_STREAM_URL`.
+        pace: Sleep between chunks so audio is sent at roughly real time. Leave
+            this on for file playback; turn it off for live microphone input,
+            which is already real time.
+        keywords: Terms to bias recognition toward -- names, jargon, product
+            words the model would otherwise mis-hear.
+        language_bias: Hints about the expected language. Omit to let the model
+            detect it.
+
+    Yields:
+        Flat event dicts, each with a `type` key. See the recipe README for the
+        full event list.
+    """
+    token = token or os.environ.get("MODEL_API_KEY")
+    if not token:
+        raise RuntimeError("Set MODEL_API_KEY to your Model API key.")
+    model = model or DEFAULT_MODEL
+
+    handshake = {
+        "mode": mode,
+        # The credential rides inside the handshake JSON rather than in an HTTP
+        # `Authorization` header, because a browser cannot set headers on a
+        # WebSocket. An unrecognised token is rejected here, before any audio.
+        "authorization": {"accessToken": token},
+        # Enum fields travel as their NAME string, never a number.
+        "audioEncoding": encoding,
+        "model": model,
+        # Each partial replaces the last, which is what the CLIs render in
+        # place. `DELTA` is also accepted, but this recipe does not use it.
+        "partialMode": "CUMULATIVE",
+        "emitAudioProgress": False,
+    }
+    # Both are optional, and only sent when set: the server ignores
+    # unrecognised handshake fields silently, so an empty value would look
+    # identical to a working one and hide a typo.
+    if keywords:
+        handshake["keywords"] = keywords
+    if language_bias:
+        handshake["languageBias"] = language_bias
+
+    resolved_url = url or DEFAULT_STREAM_URL
+    async with websockets.connect(resolved_url, max_size=None) as ws:
+        await ws.send(json.dumps(handshake))
+
+        # Read the handshake response before sending any audio. The server
+        # always answers the handshake first, so a rejected one (unknown model,
+        # unsupported mode, bad credential) surfaces here as a clean error
+        # rather than as a closed socket midway through the upload.
+        try:
+            ack = _normalize(json.loads(await ws.recv()))
+        except websockets.exceptions.ConnectionClosed as exc:
+            raise (
+                _closed(exc) or StreamError("closed before the handshake response")
+            ) from exc
+        if ack["type"] == "error":
+            raise StreamError(ack.get("message", "handshake rejected"))
+        yield ack
+
+        # Upload in the background so the loop below surfaces transcripts while
+        # audio is still being sent. Sending everything first and reading
+        # afterwards produces the same final transcript, but none of it arrives
+        # until the whole clip has been uploaded -- which for a real recording
+        # means no output at all until the end.
+        sender = asyncio.create_task(
+            _send_audio(
+                ws,
+                chunks,
+                pace=pace,
+                encoding=encoding,
+                end_frame=json.dumps({"type": "endStream"}),
+            )
+        )
+        # Set only when this function deliberately raises, so the `finally`
+        # below can tell "we are already reporting a failure" from "the
+        # generator is being torn down". Checking `sys.exc_info()` instead
+        # would also see a `GeneratorExit` -- raised when a consumer breaks out
+        # of the loop early -- and silently drop a real upload error.
+        reporting = False
+        try:
+            async for message in ws:
+                if isinstance(message, bytes):
+                    continue
+                event = _normalize(json.loads(message))
+                if event["type"] == "error":
+                    reporting = True
+                    raise StreamError(event.get("message", "unknown transcription error"))
+                yield event
+        except websockets.exceptions.ConnectionClosed as exc:
+            failure = _closed(exc)
+            if failure:
+                reporting = True
+                raise failure from exc
+        finally:
+            # Surface an upload failure rather than letting it vanish with the
+            # cancelled task, unless we are already reporting one -- raising
+            # from a `finally` replaces the original exception and would hide
+            # the more informative one.
+            sender.cancel()
+            upload = (await asyncio.gather(sender, return_exceptions=True))[0]
+            if not reporting and isinstance(upload, BaseException):
+                if isinstance(upload, websockets.exceptions.ConnectionClosed):
+                    failure = _closed(upload)
+                    if failure:
+                        raise failure from upload
+                elif not isinstance(upload, asyncio.CancelledError):
+                    raise upload
+
+
+def transcribe_recording(
+    path: str,
+    *,
+    mode: str = DEFAULT_MODE,
+    model: str | None = None,
+    token: str | None = None,
+    keywords: list[str] | None = None,
+    language_bias: list[str] | None = None,
+    session_id: str | None = None,
+    url: str | None = None,
+    timeout: int = 300,
+) -> dict[str, Any]:
+    """POST a recording and return the parsed JSON response.
+
+    Args:
+        path: Path to the audio file.
+        mode: `PUSH_TO_TALK`, `ENDPOINTING`, or `DIARIZATION`.
+        model: Public model name. Defaults to `DEFAULT_MODEL`.
+        token: Credential. Defaults to `$MODEL_API_KEY`.
+        keywords: Terms to bias recognition toward -- names, jargon, product
+            words the model would otherwise mis-hear.
+        language_bias: Hints about the expected language. Omit to let the model
+            detect it.
+        session_id: Correlation id, sent as a query param so it is known before
+            the (potentially large) body finishes uploading.
+        url: One-shot endpoint. Defaults to `DEFAULT_TRANSCRIBE_URL`.
+        timeout: Seconds to wait. A 10-minute recording needs a generous value.
+
+    Returns:
+        `{"sessionId", "transcript", "audioDurationMs", "turns": [...]}`.
+        `turns` is present only in the speech modes, and each turn carries
+        `speaker` only in `DIARIZATION`.
+    """
+    token = token or os.environ.get("MODEL_API_KEY")
+    if not token:
+        raise RuntimeError("Set MODEL_API_KEY to your Model API key.")
+    model = model or DEFAULT_MODEL
+
+    size = os.path.getsize(path)
+    if size > MAX_BYTES:
+        raise TranscribeError(
+            f"{path} is {size / 1024 / 1024:.1f} MB; the limit is 32 MB. "
+            "Split the recording, or stream it through /v1/asr/realtime instead."
+        )
+
+    request: dict[str, Any] = {
+        "mode": mode,
+        "model": model,
+        AUDIO_FORMAT_FIELD: AUDIO_FORMAT_VALUE,
+    }
+    if keywords:
+        request["keywords"] = keywords
+    if language_bias:
+        request["languageBias"] = language_bias
+
+    with open(path, "rb") as audio:
+        response = requests.post(
+            url or DEFAULT_TRANSCRIBE_URL,
+            params={"sessionId": session_id} if session_id else None,
+            headers={"Authorization": f"{AUTH_SCHEME} {token}"},
+            files={
+                # The params travel as a JSON part, not as form fields.
+                "request": (None, json.dumps(request), "application/json"),
+                "audio": (os.path.basename(path), audio),
+            },
+            timeout=timeout,
+        )
+
+    if response.status_code != 200:
+        hint = {
+            400: "audio longer than the 10-minute cap, or a malformed request",
+            401: "the credential was not accepted",
+            404: "endpoint not found",
+            413: "body over 32 MB",
+            429: "rate limited; back off and retry",
+            500: "the server exceeded its processing budget",
+        }.get(response.status_code, "unexpected response")
+        raise TranscribeError(f"[{response.status_code}] {hint}: {response.text[:300]}")
+
+    return response.json()

--- a/06_muse_voice/README.md
+++ b/06_muse_voice/README.md
@@ -1,0 +1,19 @@
+# Muse Voice Transcribe
+
+Recipes for building with [Muse Voice Transcribe](https://dev.meta.ai/docs/speech-to-text), the streaming speech-to-text model on the Meta Model API. The full contract lives in the [API reference](https://dev.meta.ai/docs/api-reference/voice). Speech goes in over a WebSocket and transcripts come back while the speaker is still talking, with punctuation, speech-boundary detection and speaker attribution handled by the model rather than by extra components in your pipeline.
+
+There are two ways in. `/v1/asr/realtime` is a WebSocket for live audio, and the one part of the Model API that is not an HTTP endpoint — real-time transcription needs a bidirectional connection, so these recipes use a WebSocket client rather than the OpenAI SDK. `/v1/asr/transcribe` is a plain HTTP `POST` for a recording you already have. Same models, same three modes, different transport.
+
+## Recipes
+
+| # | Recipe | What it does |
+|---|--------|--------------|
+| [01](01_voice_api_fundamentals/) | Speech to text | Transcribe a recording or a live microphone over the streaming WebSocket, get speaker-attributed turns with diarization, or post a whole recording in one HTTP request. |
+
+## Configuration
+
+A Model API key is the only thing these recipes need:
+
+```bash
+export MODEL_API_KEY="<your Model API key>"
+```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,45 @@ End-to-end patterns: multimodal perception, orchestration, and full applications
 | 12 | [Computer use](03_use_cases/12_computer_use/) | Drive a Linux desktop from screenshots — the agent finds an app, opens it, and plays it, clicking through a Cua sandbox. |
 | 13 | [macOS computer use](03_use_cases/13_macos_cua/) | Drive a real Mac from screenshots with `metacua`, a native computer-use agent (Swift + Python) that clicks, types, and works out a GUI app on its own. |
 
+### [4. Muse Code](04_muse_code/)
+
+Build agents with sessions you can audit, safety that fails closed, and an agent team you can steer — each recipe ends with a proof point you can replay.
+
+| # | Recipe | What it does |
+|---|--------|--------------|
+| 01 | [Append-only audit log and crash-safe resume](04_muse_code/01_append_only_audit_log/) | Export the append-only session log and walk the exact sequence of actions and approvals as replayable evidence, then kill the harness mid-task and resume where it stopped with no duplicate side effects. |
+| 02 | [Deterministic Replay in CI](04_muse_code/02_deterministic_replay/) | Turn recorded Muse Code events into a focused golden fixture and replay its model-context projection as a merge-blocking check. |
+| 03 | [Staged approvals for compound shell commands](04_muse_code/03_staged_approvals/) | Decompose a compound shell command into stages, auto-clear the safe ones, and hold the dangerous or unparseable ones for review — trust scoped per action and per workspace, failing closed. |
+| 04 | [Contained execution you can prove](04_muse_code/04_contained_execution/) | Run shell commands inside an OS-level sandbox that live-probes its own enforcement and refuses to run when containment is not actually enforcing. |
+| 05 | [The agent can't rewrite its own rules](04_muse_code/05_immutable_guardrails/) | Ask the agent to edit the guardrail file it runs under; the write stops for human review with no standing grant on offer, and a shell write to the same path fails read-only at the sandbox. |
+| 06 | [Subagent fanout across isolated worktrees](04_muse_code/06_subagent_fanout/) | Fan one job out to parallel subagents, each in its own git worktree, steered or stopped from a single command center. |
+| 07 | [Goal tracking with a judge](04_muse_code/07_goal_tracking/) | Declare a goal once; a judge decides whether the work is actually done and refuses to close the turn until every acceptance check passes. |
+| 08 | [Bundled skills: a paved road from idea to shipped](04_muse_code/08_bundled_skills/) | Drive the built-in `/plan`, `/grilling`, `/grill-with-docs`, and `/taste` skills end to end — plan a change, stress-test it, record the decisions, and build UI that does not look AI-made. |
+| 09 | [Loop and cron: scheduled agent work](04_muse_code/09_loop_and_cron/) | Schedule recurring or one-time agent work in natural language, then view, change, or cancel it from the same chat surface. |
+| 10 | [Multi-turn side chats](04_muse_code/10_side_chats/) | Branch a multi-turn side conversation off a busy main thread with `/side` (or its alias `/btw`), isolated from the main transcript. |
+
+### [5. Muse Image](05_muse_image/)
+
+Generate and edit images through the conversational Responses API, driving each task end to end
+in one chained conversation.
+
+| # | Recipe | What it does |
+|---|--------|--------------|
+| 01 | [Generate, edit, and compose images](05_muse_image/01_image_api_fundamentals/) | Drive Muse Image through the Responses API: generate an image from a prompt, refine it over chained turns, and attach reference images to steer or compose several into one scene. |
+| 02 | [Ground image generation in web search](05_muse_image/02_backyard_restyle/) | Let the model search the live web mid-generation, so it renders from furniture actually sold today, then place a coordinated outdoor set into a photo of a real backyard. |
+| 03 | [Consistency across an image series](05_muse_image/03_anchored_generation/) | Anchor a whole series on a small reference set and carry it through the conversation, so the character, style, and setting stay on-model from one image to the next. |
+| 04 | [Editing with image understanding and reasoning](05_muse_image/04_image_editing_with_reasoning/) | Edit a specific part of an image by describing it, letting the model reason over the frame and refine the same image across turns, changing what you ask for while preserving the rest. |
+
+### [6. Muse Voice Transcribe](06_muse_voice/)
+
+Turn speech into text as it is spoken. Muse Voice Transcribe is the one part of the Model API
+that is not an HTTP endpoint — real-time transcription needs a bidirectional connection, so
+these recipes use a WebSocket client rather than the OpenAI SDK.
+
+| # | Recipe | What it does |
+|---|--------|--------------|
+| 01 | [Speech to text](06_muse_voice/01_voice_api_fundamentals/) | Transcribe a recording or a live microphone over the streaming WebSocket, get speaker-attributed turns with diarization, or post a whole recording in one HTTP request. |
+
 ## License
 
 See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds the first Muse Voice Transcribe recipe, covering both public endpoints for
speech to text on the Meta Model API.

| Script | Endpoint | Use it when |
|---|---|---|
| `transcribe_stream.py` | `wss://api.meta.ai/v1/asr/realtime` | You want transcripts while the speaker is still talking — a microphone, a call, or a file played at real time |
| `transcribe_file.py` | `https://api.meta.ai/v1/asr/transcribe` | You already have a recording and just want the text back |

Shared client code for both lives in `utils.py`. `MODEL_API_KEY` is the only
environment variable a reader has to set.

The recipe covers all three modes (`PUSH_TO_TALK`, `ENDPOINTING`, `DIARIZATION`),
speaker attribution with diarization, cumulative partial transcripts, vocabulary
and language biasing, and the session cutoff behaviour.

### Also in this PR

The root README was missing the Muse Code and Muse Image sections even though
both directories already exist in the repo, so section numbering jumped from 3
to 6. This fills both in — numbering now runs 1–6 with no gaps.

### Verification

Both endpoints run end to end against `api.meta.ai`: all three modes, speaker
labels with timings, repeated `--keywords` and `--language-bias`, and 16 kHz
input. Verified from a clean checkout of this branch.