### PR TITLE
Trim the Voice Chess recipe README

### DIFF
--- a/06_muse_voice/02_voice_chess_cua/README.md
+++ b/06_muse_voice/02_voice_chess_cua/README.md
@@ -16,7 +16,7 @@
 Voice Chess turns a spoken utterance such as `Move E2 to E4` into a validated Apple Chess action. Muse Voice Transcribe supplies speech-turn detection, vocabulary biasing, and partial transcripts for a responsive voice experience. A deterministic local parser then accepts only the exact move grammar, with no second model request, and a macOS computer-use layer validates Chess through the Accessibility API, posts only the two approved clicks, and confirms that the move occurred.
 
 > [!IMPORTANT]
-> Execution is automatic and there is no wake phrase. Start with `--dry-run`, use headphones in a quiet environment, and keep one Apple Chess game window visible.
+> Execution is automatic and there is no wake phrase. Start with `--dry-run`, speak in a quiet environment, and keep one Apple Chess game window visible.
 
 ## Setup
 

--- a/06_muse_voice/02_voice_chess_cua/README.md
+++ b/06_muse_voice/02_voice_chess_cua/README.md
@@ -13,12 +13,10 @@
 **[Watch the 50-second Voice Chess demo](assets/voice-cua-chess.mp4)**
 
 
-Voice Chess turns a completed Muse Voice Transcribe utterance such as `Move E2 to E4` into a narrowly scoped Apple Chess action. A deterministic local parser accepts only the exact move grammar. A purpose-built macOS computer-use layer then validates Apple Chess through the Accessibility API, performs only the approved source-and-destination clicks through Quartz/CoreGraphics, and confirms that the requested move occurred before reporting success.
-
-Muse Voice Transcribe provides vocabulary biasing, speech-turn detection, and partial transcripts for a responsive voice experience. After a current `speechComplete` event, parsing is entirely local: there is no second model request and no transcript cleanup, prompt, tool call, response schema, or conversation history.
+Voice Chess turns a spoken utterance such as `Move E2 to E4` into a validated Apple Chess action. Muse Voice Transcribe supplies speech-turn detection, vocabulary biasing, and partial transcripts for a responsive voice experience. A deterministic local parser then accepts only the exact move grammar, with no second model request, and a macOS computer-use layer validates Chess through the Accessibility API, posts only the two approved clicks, and confirms that the move occurred.
 
 > [!IMPORTANT]
-> Execution is automatic and there is no wake phrase. Start with `--dry-run`, use headphones in a quiet environment, and keep one Apple Chess game window visible. Every invocation automatically finds and activates the exact `com.apple.Chess` process. An already-running Chess window and current game are reused, and Chess is launched only when absent.
+> Execution is automatic and there is no wake phrase. Start with `--dry-run`, use headphones in a quiet environment, and keep one Apple Chess game window visible.
 
 ## Setup
 
@@ -30,90 +28,60 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -e .
 export MODEL_API_KEY="<your Meta Model API key>"
-```
-
-`MODEL_API_KEY` is the only credential source. Request the three required macOS permissions before starting Voice Chess:
-
-```bash
 voice-chess --request-permissions
 ```
 
-Allow the terminal or Python host under **System Settings > Privacy & Security > Microphone**, **Accessibility**, and **Screen Recording**. Screen Recording is required for ScreenCaptureKit window discovery; Voice Chess does not capture screenshots. If macOS asks you to restart the host after granting Screen Recording, close and reopen that terminal before running Voice Chess.
+`MODEL_API_KEY` is the only credential source. Allow the terminal or Python host under **System Settings > Privacy & Security > Microphone**, **Accessibility**, and **Screen Recording**. Screen Recording is used to discover the Chess window; no screenshot is captured. If macOS asks you to restart the host, reopen that terminal before continuing.
 
-The recipe uses the fixed public Muse Voice Transcribe contract `muse-voice-transcribe-1.0` at `wss://api.meta.ai/v1/asr/realtime`. Realtime transcription access may be limited during rollout.
-
-If the ASR startup event reports `classification="tls_verification_failed"` on macOS, point Python at the system certificate bundle for that invocation:
-
-```bash
-SSL_CERT_FILE=/etc/ssl/cert.pem voice-chess --dry-run
-```
-
-Confirm that `/etc/ssl/cert.pem` exists first. This override is not needed when the selected Python installation already has a working CA trust store.
+The recipe uses the fixed public contract `muse-voice-transcribe-1.0` at `wss://api.meta.ai/v1/asr/realtime`. Realtime transcription access may be limited during rollout.
 
 ## Run
 
-Voice starts after the exact `com.apple.Chess` process is bound. If Chess is already running, Voice Chess activates and reuses it. Otherwise, Voice Chess launches and activates it. Stopping Voice Chess never quits Chess.
-
-First validate commands and the board without posting native input:
+Voice Chess activates Apple Chess itself, launching it only when it is not already running. Validate commands and the board without posting native input first:
 
 ```bash
 voice-chess --dry-run
 ```
 
-The overlay is always enabled. Its HUD reports `VOICE`, `TURN`, and `HEARD` as soon as startup reaches the display stage, even while board detection is still searching. When the bound Chess process exposes a supported board, the same passive overlay draws the labeled grid. The overlay is observational and does not broaden what the executor may click.
-
-If visual tracking cannot validate the board, the terminal reports one bounded warning such as `screen_capture_permission`, `window_discovery_timeout`, `window_unavailable`, `window_ambiguous`, `unsupported_orientation`, `layout_mismatch`, or `detection_failed`. Repeated detection attempts do not repeat the same warning. Keep a single visible, non-minimized, White-at-bottom Apple Chess game window in the standard layout; for `screen_capture_permission`, grant Screen Recording to the terminal or Python host and restart that host.
-
-Then enable automatic validated execution:
+Then enable execution and say one move:
 
 ```bash
 voice-chess
 ```
 
-Quitting or restarting Chess while Voice Chess is running requires restarting Voice Chess; a replacement process is never adopted automatically. Stop Voice Chess with `Control-C`.
+```text
+Move E2 to E4
+```
 
-## Exact Command Grammar
+An always-on HUD reports `VOICE`, `TURN`, and `HEARD`, and a passive overlay draws the labeled grid once the board is validated. Stop with `Control-C`; stopping Voice Chess never quits Chess.
 
-Say one completed utterance in exactly this form:
+## Command Grammar
 
 ```text
 Move A1 to B2
 ```
 
-The parser performs a case-insensitive ASCII full match. One trailing period is optional. Files must be `A` through `H`, ranks must be `1` through `8`, and source and destination must differ. Accepted squares are normalized to uppercase before local validation.
+A case-insensitive full match, with an optional trailing period. Files are `A` through `H`, ranks are `1` through `8`, and the two squares must differ. Everything else is rejected and executes nothing: the parser does not repair spacing, convert spoken ranks such as `E two`, or lift a move out of surrounding words.
 
-Everything else is rejected. The parser does not strip leading or trailing whitespace, collapse spaces, accept tabs or newlines, convert spoken ranks such as `E two`, accept extra punctuation, or extract a move from surrounding words. A rejected transcript executes nothing.
+## Requirements and Safety
 
-## Runtime Pipeline
+- Use one visible, non-minimized Apple Chess game window with White at the bottom and the standard board layout. Black-at-bottom and auto-rotating Human-vs-Human boards are rejected.
+- Only the exact `com.apple.Chess` process is acquired, and its PID is fixed for the run. Quitting or restarting Chess requires restarting Voice Chess.
+- Partial, stale, duplicate, and superseded transcription events cannot authorize a move, and microphone frames observed during a move are dropped.
+- Every move is revalidated immediately before input and confirmed afterward. Any failed check posts nothing, and native input is never retried automatically.
+- Transcripts are sent only to Muse Voice Transcribe. Window metadata, Accessibility state, coordinates, and input events stay on the machine.
 
-| Stage | Input | Output and authority |
-|---|---|---|
-| **Voice API: `muse-voice-transcribe-1.0`** | A long-lived `ENDPOINTING` WebSocket starts with authentication, `PCM_24KHZ`, cumulative partials, and chess keyword hints; subsequent binary messages contain 24 kHz mono PCM16 microphone frames. | `speechStart` opens a `turnId`; `transcript` events are display-only; `speechComplete` carries the completed turn text. Parsing accepts only a current, nonempty, command-eligible completion. A partial or keyword match never authorizes execution. |
-| **Local exact parser** | One eligible final transcript, unchanged from the Voice API. | The ASCII full match returns either one move with uppercase, distinct `A1`-`H8` squares or a rejection. No second model request is made. |
-| **Local CUA handoff** | Only an accepted move may enter the Apple Chess executor. | Apple Chess inspection, validation, coordinates, input, and confirmation remain local. Rejected text or failed local validation executes nothing. |
+## Troubleshooting
 
-The parsed move is a proposal, not permission to click. The local executor must still validate Apple Chess before input and confirm the requested board change afterward.
+If the board cannot be validated, the terminal reports one bounded warning such as `window_ambiguous`, `unsupported_orientation`, or `screen_capture_permission`. Check the window requirements above; for `screen_capture_permission`, grant Screen Recording to the terminal or Python host and restart it.
 
-## Supported Layout
+If the ASR startup event reports `classification="tls_verification_failed"`, point Python at the system certificate bundle for that invocation:
 
-The board geometry comes from a window-relative calibration measured on a `979x768` Apple Chess window with White at the bottom, and the window aspect ratio must stay within 3% of that reference. Accessibility landmarks for A1, H1, A8, and H8 then validate the result: every distance between them must agree with the calibrated quad within 5%, and the wider rank identifies the near side of the board. Apple Chess reports landmark positions with the vertical axis inverted, so only the distances between landmarks are compared, never their positions. No screenshot is captured.
+```bash
+SSL_CERT_FILE=/etc/ssl/cert.pem voice-chess --dry-run
+```
 
-Voice Chess rejects Black-at-bottom boards, auto-rotating Human-vs-Human boards, and any unsupported or ambiguous layout. Use one visible, non-minimized Apple Chess game window and keep its standard board layout.
-
-Apple Chess draws its pieces standing up, so a tall piece covers part of the square behind it and the centre of that square is not always clickable. Before any input, Voice Chess asks Accessibility which square each click point resolves to, and aims progressively further towards the square's far edge until the answer is the intended square. A square that never resolves, or that resolves to another process, blocks the move with `squareNotClickable` and nothing is clicked.
-
-## Safety and Data
-
-- Only the exact `com.apple.Chess` process may be acquired. Its PID is immutable for the run, native input requires it to be active, and stopping Voice Chess never sends Chess a quit or terminate request.
-- The bound process must expose exactly one visible, non-minimized game window, valid A1/H1/A8/H8 Accessibility landmarks, and a complete, stable, geometry-validated 64-square Accessibility snapshot before input.
-- The app revalidates the bound window, board, PID, focus, source, and destination before input, requires each click point to resolve to its intended square inside the bound process, and confirms that both source and destination changed afterward. Failed checks execute nothing, and native input is never retried automatically.
-- Partial, stale, duplicate, superseded, and busy-overlapping transcription events cannot authorize a move. Microphone frames observed during a move are dropped until a local quiet boundary rearms capture.
-- Dry run performs the same binding and board validation but posts no native input. The always-on HUD remains visible while the board is being acquired, and the passive overlay ignores mouse events.
-- Transcripts are sent only to Muse Voice Transcribe. Window metadata, Accessibility state, coordinates, overlay state, and native input events are processed locally and are never uploaded.
-
-## Safety Smoke Tests
-
-The public recipe includes a focused safety suite covering exact parsing, dry-run behavior, native adapter shutdown, overlay lifecycle, structured redaction, and prepared-move execution:
+## Tests
 
 ```bash
 pip install -e ".[test]"


### PR DESCRIPTION
Shortens the Voice Chess recipe README to setup, the command grammar, the window requirements, and troubleshooting. No code changes.